### PR TITLE
Add user variable to templates

### DIFF
--- a/src/elements/TailwindTemplateCard.tsx
+++ b/src/elements/TailwindTemplateCard.tsx
@@ -159,6 +159,9 @@ export class TailwindTemplateCard extends TailwindTemplateRenderer {
       {
         type: "render_template",
         template: content,
+        variables: {
+          user: this._hass.user!.name,
+        },
       },
     );
   }


### PR DESCRIPTION
This small patch makes the `{{ user }}` variable available from within templates using this card.  In common with other cards that support frontend jinja templates, this variable contains the friendly name of the logged-in user.